### PR TITLE
fix: Removed public test version from action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -3,7 +3,6 @@ description: Report issues with the Maester Github Action here.
 title: "[BUG] "
 labels: [bug]
 body:
-body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
@@ -23,16 +22,10 @@ body:
   id: maester_version
   attributes:
     label: What version of Maester are you using?
-    description: "Please provide the version of Maester you are using, it is in the logs as: Installed Maester version: 1.0.83"
-    placeholder: 1.0.0 / 1.0.83
+    description: "Please provide the version of Maester you are using, it is in the logs as: Installed Maester version: 1.0.86"
+    placeholder: 1.0.0 / 1.0.86
   validations:
     required: true
-- type: input
-  id: public_tests_version
-  attributes:
-    label: What version of public tests are you using?
-    description: It is possible to use a different git reference for the public tests. Which one are you using?
-    placeholder: main
 - type: textarea
   id: issue_description
   attributes:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - name: Check preconditions 📃
         id: preconditions
+        shell: bash
         run: |
           if [ "${{ secrets.AZURE_CLIENT_ID }}" == "" ]; then
             echo "::error title=Missing secret::AZURE_CLIENT_ID is not set."
@@ -63,7 +64,6 @@ jobs:
           step_summary: ${{ matrix.maester == 'preview'}}
           artifact_upload: true
           maester_version: ${{ matrix.maester }}
-          public_tests_ref: main
           disable_telemetry: true
           notification_teams_webhook: https://webhook.site/6349a4fa-9f43-4224-9e37-a3f5117514d6
       

--- a/README.md
+++ b/README.md
@@ -20,28 +20,27 @@ Check out the [Maester documentation](https://maester.dev/) for more information
 
 ## 📦 Inputs
 
-| Name                          | Description                                                                                     | Required | Default                     |
-|-------------------------------|-------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `tenant_id`                   | Entra ID Tenant ID.                                                                             | ✅       |                             |
+| Name                          | Description                                                                                    | Required | Default                     |
+|-------------------------------|------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `tenant_id`                   | Entra ID Tenant ID.                                                                            | ✅       |                             |
 | `client_id`                   | App Registration Client ID.                                                                    | ✅       |                             |
-| `include_public_tests`        | Include public test repository `maester365/maester-tests` in the test run.                     | ❌       | `true`                      |
-| `public_tests_ref`            | The branch or tag of the public tests to use.                                                  | ❌       |                             |
+| `include_public_tests`        | Install public tests from module                                                               | ❌       | `true`                      |
 | `include_private_tests`       | Include private tests from the current repository.                                             | ❌       | `true`                      |
 | `include_exchange`            | Include Exchange Online tests in the test run.                                                 | ❌       | `false`                     |
 | `include_teams`               | Include Teams tests in the test run.                                                           | ❌       | `true`                      |
 | `include_tags`                | A list of tags to include in the test run (comma-separated).                                   | ❌       |                             |
 | `exclude_tags`                | A list of tags to exclude from the test run (comma-separated).                                 | ❌       |                             |
 | `maester_version`             | The version of Maester PowerShell to use (`latest`, `preview`, or specific version).           | ❌       | `latest`                    |
-| `pester_verbosity`            | Pester verbosity level (`None`, `Normal`, `Detailed`, `Diagnostic`).                          | ❌       | `None`                      |
+| `pester_verbosity`            | Pester verbosity level (`None`, `Normal`, `Detailed`, `Diagnostic`).                           | ❌       | `None`                      |
 | `step_summary`                | Output a summary to GitHub Actions.                                                            | ❌       | `true`                      |
 | `artifact_upload`             | Upload test results as GitHub Action artifacts.                                                | ❌       | `true`                      |
 | `disable_telemetry`           | Disable telemetry logging.                                                                     | ❌       | `false`                     |
-| `mail_recipients`             | A list of email addresses to send the test results to (comma-separated).                      | ❌       |                             |
+| `mail_recipients`             | A list of email addresses to send the test results to (comma-separated).                       | ❌       |                             |
 | `mail_userid`                 | The user ID of the sender of the email.                                                        | ❌       |                             |
 | `mail_testresultsuri`         | URI to the detailed test results page.                                                         | ❌       | `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}` |
 | `notification_teams_webhook`  | Webhook URL for sending test results to Teams.                                                 | ❌       |                             |
-| `notification_teams_channel_id` | The ID of the Teams channel to send the test results to.                                      | ❌       |                             |
-| `notification_teams_team_id`  | The ID of the Teams team to send the test results to.                                           | ❌       |                             |
+| `notification_teams_channel_id` | The ID of the Teams channel to send the test results to.                                     | ❌       |                             |
+| `notification_teams_team_id`  | The ID of the Teams team to send the test results to.                                          | ❌       |                             |
 
 ## 📤 Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -41,11 +41,6 @@ inputs:
     description: "The version of Maester PowerShell to use. latest (default), preview, or a specific version number."
     required: false
     default: "latest"
-  
-  public_tests_ref:
-    description: "The branch or tag of the public tests to use. If not specified, the default branch will be used."
-    required: false
-    default: ""
 
   pester_verbosity:
     description: "Pester verbosity level. Options: 'None', 'Normal', 'Detailed', 'Diagnostic'"


### PR DESCRIPTION
This action was using `checkout` to get public tests, which is been replaced by installing the public tests from the the module. The `public_tests_ref` was no longer used and needs to go.

After this PR, we should create a new release, because we want people to use a pinned version instead of `@main`. Which was one of the goals of creating a separate repo for it