### PR TITLE
Spelling and Formatting

### DIFF
--- a/script/Get-MtMarkdownReportAction.ps1
+++ b/script/Get-MtMarkdownReportAction.ps1
@@ -1,14 +1,14 @@
 <#
- .Synopsis
-  Generates a markdown report using the Maester test results format.
+.Synopsis
+    Generates a markdown report using the Maester test results format.
 
- .Description
+.Description
     This markdown report can be used in GitHub actions to display the test results in a formatted way.
 
- .Example
-    $pesterResults = Invoke-Pester -PassThru
-    $maesterResults = ConvertTo-MtMaesterResult -PesterResults $pesterResults
-    Get-MtMarkdownReport $maesterResults
+.Example
+    $PesterResults = Invoke-Pester -PassThru
+    $MaesterResults = ConvertTo-MtMaesterResult -PesterResults $PesterResults
+    Get-MtMarkdownReport $MaesterResults
 #>
 
 function Get-MtMarkdownReportAction {
@@ -21,92 +21,93 @@ function Get-MtMarkdownReportAction {
         [Parameter(Mandatory = $false, Position = 1)]
         [string] $TemplateFile = [IO.Path]::Combine($PSScriptRoot, '..', 'assets', 'ReportTemplate.md')
     )
+
     $StatusIcon = @{
-        Passed = '<img src="https://maester.dev/img/test-result/pill-pass.png" height="25" alt="Passed"/>'
-        Failed = '<img src="https://maester.dev/img/test-result/pill-fail.png" height="25" alt="Failed"/>'
-        NotRun = '<img src="https://maester.dev/img/test-result/pill-notrun.png" height="25" alt="Not Run"/>'
+        Passed  = '<img src="https://maester.dev/img/test-result/pill-pass.png" height="25" alt="Passed"/>'
+        Failed  = '<img src="https://maester.dev/img/test-result/pill-fail.png" height="25" alt="Failed"/>'
+        NotRun  = '<img src="https://maester.dev/img/test-result/pill-notrun.png" height="25" alt="Not Run"/>'
         Skipped = '<img src="https://maester.dev/img/test-result/pill-notrun.png" height="25" alt="Not Run"/>'
     }
 
     $StatusIconSm = @{
-        Passed = '✅' # '<img src="https://maester.dev/img/test-result/icon-pass.png" alt="Passed icon" height="18" />'
-        Failed = '❌' # '<img src="https://maester.dev/img/test-result/icon-fail.png" alt="Failed icon" height="18" />'
-        NotRun = '❔' # '<img src="https://maester.dev/img/test-result/icon-notrun.png" alt="Not Run icon" height="18" />'
+        Passed  = '✅' # '<img src="https://maester.dev/img/test-result/icon-pass.png" alt="Passed icon" height="18" />'
+        Failed  = '❌' # '<img src="https://maester.dev/img/test-result/icon-fail.png" alt="Failed icon" height="18" />'
+        NotRun  = '❔' # '<img src="https://maester.dev/img/test-result/icon-notrun.png" alt="Not Run icon" height="18" />'
         Skipped = '🚫' # '<img src="https://maester.dev/img/test-result/icon-notrun.png" alt="Not Run icon" height="18" />'
     }
 
     function GetTestSummary() {
-        $summary = @'
+        $Summary = @'
 |Test|Status|
 |-|:-:|
 
 '@
-        foreach ($test in $MaesterResults.Tests) {
-            $summary += "| $($test.Name) | $($StatusIcon[$test.Result]) |`n"
+        foreach ($Test in $MaesterResults.Tests) {
+            $Summary += "| $($Test.Name) | $($StatusIcon[$Test.Result]) |`n"
         }
-        return $summary
+        return $Summary
     }
 
     function GetTestDetails() {
 
-        foreach ($test in $MaesterResults.Tests) {
+        foreach ($Test in $MaesterResults.Tests) {
 
-            $details += "### $($StatusIconSm[$test.Result]) $($test.Name)`n`n"
+            $Details += "### $($StatusIconSm[$Test.Result]) $($Test.Name)`n`n"
 
-            $details += $StatusIcon[$test.Result] -replace 'src', 'align="right" src'
-            $details += "`n`n"
+            $Details += $StatusIcon[$Test.Result] -replace 'src', 'align="right" src'
+            $Details += "`n`n"
 
-            if (![string]::IsNullOrEmpty($test.ResultDetail)) {
+            if (![string]::IsNullOrEmpty($Test.ResultDetail)) {
                 # Test author has provided details
-                $details += "#### Overview`n`n$($test.ResultDetail.TestDescription)`n`n"
-                $details += "#### Test Results`n`n$($test.ResultDetail.TestResult)`n`n"
+                $Details += "#### Overview`n`n$($Test.ResultDetail.TestDescription)`n`n"
+                $Details += "#### Test Results`n`n$($Test.ResultDetail.TestResult)`n`n"
             } else {
                 # Test author has not provided details, use default code in script
                 # make sure we do not execute the code in the script block!
-                $cleanedScriptBlock = $test.ScriptBlock.ToString() -replace '%\w+%', '' -replace '\$_', '€_' # or show me how I can make it not execute the $_ thing
-                $details += "#### Overview`n`n``````ps1`n$cleanedScriptBlock`n```````n`n"
-                if (![string]::IsNullOrEmpty($test.ErrorRecord)) {
-                    $details += "#### Reason for failure`n`n$($test.ErrorRecord)`n`n"
+                $CleanedScriptBlock = $Test.ScriptBlock.ToString() -replace '%\w+%', '' -replace '\$_', '€_' # or show me how I can make it not execute the $_ thing
+                $Details += "#### Overview`n`n``````ps1`n$CleanedScriptBlock`n```````n`n"
+                if (![string]::IsNullOrEmpty($Test.ErrorRecord)) {
+                    $Details += "#### Reason for failure`n`n$($Test.ErrorRecord)`n`n"
                 }
             }
 
-            if (![string]::IsNullOrEmpty($test.HelpUrl)) { $details += "**Learn more**: [$($test.HelpUrl)]($($test.HelpUrl))`n`n" }
-            if (![string]::IsNullOrEmpty($test.Tag)) {
-                $tags = '`{0}`' -f ($test.Tag -join '` `')
-                $details += "**Tag**: $tags`n`n"
+            if (![string]::IsNullOrEmpty($Test.HelpUrl)) { $Details += "**Learn more**: [$($Test.HelpUrl)]($($Test.HelpUrl))`n`n" }
+            if (![string]::IsNullOrEmpty($Test.Tag)) {
+                $Tags = '`{0}`' -f ($Test.Tag -join '` `')
+                $Details += "**Tag**: $Tags`n`n"
             }
 
-            if (![string]::IsNullOrEmpty($test.Block)) {
-                $category = '`{0}`' -f ($test.Block -join '` `')
-                $details += "**Category**: $category`n`n"
+            if (![string]::IsNullOrEmpty($Test.Block)) {
+                $Category = '`{0}`' -f ($Test.Block -join '` `')
+                $Details += "**Category**: $Category`n`n"
             }
 
-            if (![string]::IsNullOrEmpty($test.ScriptBlockFile)) { $details += "**Source**: ``$($test.ScriptBlockFile)```n`n" }
+            if (![string]::IsNullOrEmpty($Test.ScriptBlockFile)) { $Details += "**Source**: ``$($Test.ScriptBlockFile)```n`n" }
 
-            $details += "---`n`n"
+            $Details += "---`n`n"
         }
 
-        return $details
+        return $Details
     }
 
-    #$markdownFilePath = Join-Path -Path $PSScriptRoot -ChildPath '../assets/ReportTemplate.md'
-    $templateMarkdown = Get-Content -Path $TemplateFile -Raw
+    #$MarkdownFilePath = Join-Path -Path $PSScriptRoot -ChildPath '../assets/ReportTemplate.md'
+    $TemplateMarkdown = Get-Content -Path $TemplateFile -Raw
 
-    $textSummary = GetTestSummary
-    $textDetails = GetTestDetails
+    $TextSummary = GetTestSummary
+    $TextDetails = GetTestDetails
 
-    $templateMarkdown = $templateMarkdown -replace '%TenantId%', $MaesterResults.TenantId
-    $templateMarkdown = $templateMarkdown -replace '%TenantName%', $MaesterResults.TenantName
-    $templateMarkdown = $templateMarkdown -replace '%TenantName%', $MaesterResults.TenantVersion
-    $templateMarkdown = $templateMarkdown -replace '%ModuleVersion%', $MaesterResults.CurrentVersion
-    $templateMarkdown = $templateMarkdown -replace '%TestDate%', $MaesterResults.ExecutedAt
-    $templateMarkdown = $templateMarkdown -replace '%TotalCount%', $MaesterResults.TotalCount
-    $templateMarkdown = $templateMarkdown -replace '%PassedCount%', $MaesterResults.PassedCount
-    $templateMarkdown = $templateMarkdown -replace '%FailedCount%', $MaesterResults.FailedCount
-    $templateMarkdown = $templateMarkdown -replace '%NotRunCount%', $MaesterResults.NotRunCount
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TenantId%', $MaesterResults.TenantId
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TenantName%', $MaesterResults.TenantName
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TenantName%', $MaesterResults.TenantVersion
+    $TemplateMarkdown = $TemplateMarkdown -replace '%ModuleVersion%', $MaesterResults.CurrentVersion
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TestDate%', $MaesterResults.ExecutedAt
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TotalCount%', $MaesterResults.TotalCount
+    $TemplateMarkdown = $TemplateMarkdown -replace '%PassedCount%', $MaesterResults.PassedCount
+    $TemplateMarkdown = $TemplateMarkdown -replace '%FailedCount%', $MaesterResults.FailedCount
+    $TemplateMarkdown = $TemplateMarkdown -replace '%NotRunCount%', $MaesterResults.NotRunCount
 
-    $templateMarkdown = $templateMarkdown -replace '%TestSummary%', $textSummary
-    $templateMarkdown = $templateMarkdown -replace '%TestDetails%', $textDetails
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TestSummary%', $TextSummary
+    $TemplateMarkdown = $TemplateMarkdown -replace '%TestDetails%', $TextDetails
 
-    return $templateMarkdown
+    return $TemplateMarkdown
 }

--- a/script/Get-MtMarkdownReportAction.ps1
+++ b/script/Get-MtMarkdownReportAction.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .Synopsis
     Generates a markdown report using the Maester test results format.
 

--- a/script/Get-MtMarkdownReportAction.ps1
+++ b/script/Get-MtMarkdownReportAction.ps1
@@ -16,7 +16,7 @@ function Get-MtMarkdownReportAction {
     param(
         # The Maester test results returned from `Invoke-Pester -PassThru | ConvertTo-MtMaesterResult`
         [Parameter(Mandatory = $true, Position = 0)]
-        [psobject] $MaesterResults,
+        [PSObject] $MaesterResults,
 
         [Parameter(Mandatory = $false, Position = 1)]
         [string] $TemplateFile = [IO.Path]::Combine($PSScriptRoot, '..', 'assets', 'ReportTemplate.md')
@@ -95,7 +95,7 @@ function Get-MtMarkdownReportAction {
     $textSummary = GetTestSummary
     $textDetails = GetTestDetails
 
-    $templateMarkdown = $templateMarkdown -replace '%TenandId%', $MaesterResults.TenantId
+    $templateMarkdown = $templateMarkdown -replace '%TenantId%', $MaesterResults.TenantId
     $templateMarkdown = $templateMarkdown -replace '%TenantName%', $MaesterResults.TenantName
     $templateMarkdown = $templateMarkdown -replace '%TenantName%', $MaesterResults.TenantVersion
     $templateMarkdown = $templateMarkdown -replace '%ModuleVersion%', $MaesterResults.CurrentVersion


### PR DESCRIPTION
## Code Standards and Consistency

* Standardized variable names to use Pascal case (e.g., `$PesterResults`, `$MaesterResults`, `$TemplateMarkdown`, etc.) for consistency with PowerShell conventions. [[1]](diffhunk://#diff-c6ee0cb747550cd89c40b9c2f77456728064a1f5208ea0933c1249e942d95255L9-R24) [[2]](diffhunk://#diff-c6ee0cb747550cd89c40b9c2f77456728064a1f5208ea0933c1249e942d95255L39-R112)
* Updated type declaration for the `MaesterResults` parameter from `[psobject]` to `[PSObject]` to use the correct casing for the type.

## Spelling
* Fixed typo in `'%TenandId%'` placeholder.