### PR TITLE
Fix permission for federated token

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,14 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+      id-token: write
+      contents: read
+      checks: write
+
 jobs:
   test:
+    name: Run Maester Test Job
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Description

When using "federated token" more permissions are needed:

> Error: Failed to fetch federated token from GitHub. Please make sure to give write permissions to id-token in the workflow.
> Error: Login failed with Error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable. Double check if the 'auth-type' is correct. Refer to https://github.com/Azure/login#readme for more information.
> 
