### PR TITLE
Fix error handling in Run-MaesterAction.ps1

### DIFF
--- a/script/Run-MaesterAction.ps1
+++ b/script/Run-MaesterAction.ps1
@@ -244,8 +244,8 @@ PROCESS {
         $results = Invoke-Maester @MaesterParameters
         Write-Host "🕑 Maester tests executed $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
     } catch {
-        Write-Error "Failed to run Maester tests. Please check the parameters. $($_.Exception.Message) at $($_.InvocationInfo.Line) in $($_.InvocationInfo.ScriptName)"
-        Write-Host "::error file=$($_.InvocationInfo.ScriptName),line=$($_.InvocationInfo.Line),title=Maester exception::Failed to run Maester tests. Please check the parameters."
+        Write-Error "Failed to run Maester tests. Please check the parameters. $($_.Exception.Message) at $($_.InvocationInfo.ScriptLineNumber) in $($_.InvocationInfo.ScriptName)"
+        Write-Host "::error file=$($_.InvocationInfo.ScriptName),line=$($_.InvocationInfo.ScriptLineNumber),title=Maester exception::Failed to run Maester tests. Please check the parameters."
         exit $LASTEXITCODE
         return
     }


### PR DESCRIPTION
### Description

Use `$_.InvocationInfo.ScriptLineNumber` to show the line number during error handling as desired (instead of `$_.InvocationInfo.Line`).

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://github.com/maester365/maester-action/tree/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main branch!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *maester-action/main*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
- [x] If changing anything in the action, make sure it still works and is backward compatible.

### Review

We will try to review your pull request as soon as possible.

<!-- While your wait for a review, why not try to spread some Maester love on social media? -->

💖 Thank you!
