### PR TITLE
Fix path assignment to use .Path property

### DIFF
--- a/script/Run-MaesterAction.ps1
+++ b/script/Run-MaesterAction.ps1
@@ -120,12 +120,12 @@ BEGIN {
     if (-not [string]::IsNullOrWhiteSpace($Path)) {
         if (-not (Test-Path $Path)) {
             Write-Host "The provided path does not exist: $Path. Using current directory."
-            $Path = Get-Location
+            $Path = (Get-Location).Path
         } else {
             Write-Host "📃 Using provided path: $Path"
         }
     } else {
-        $Path = Get-Location
+        $Path = (Get-Location).Path
         Write-Host "❔ No path provided. Using current directory $Path."
     }
 }


### PR DESCRIPTION
### Description

Minor fix for the `$Path` variable to use the path string attribute instead of the full path object.

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://github.com/maester365/maester-action/tree/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main branch!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *maester-action/main*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
- [x] If changing anything in the action, make sure it still works and is backward compatible.

### Review

We will try to review your pull request as soon as possible.

<!-- While your wait for a review, why not try to spread some Maester love on social media? -->

💖 Thank you!
