### PR TITLE
Add support for IncludeLongRunning and IncludePreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Check out the [Maester documentation](https://maester.dev/) for more information
 | `include_private_tests`       | Include private tests from the current repository.                                             | ❌       | `true`                      |
 | `include_exchange`            | Include Exchange Online tests in the test run.                                                 | ❌       | `false`                     |
 | `include_teams`               | Include Teams tests in the test run.                                                           | ❌       | `true`                      |
+| `include_longrunning_tests`   | Include long running tests.                                                                    | ❌       | `false`                     |
+| `include_preview_tests`       | Include preview tests.                                                                         | ❌       | `false`                     |
 | `include_tags`                | A list of tags to include in the test run (comma-separated).                                   | ❌       |                             |
 | `exclude_tags`                | A list of tags to exclude from the test run (comma-separated).                                 | ❌       |                             |
 | `maester_version`             | The version of Maester PowerShell to use (`latest`, `preview`, or specific version).           | ❌       | `latest`                    |

--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,13 @@ inputs:
     required: false
     default: "true"
   include_exchange:
-    type: boolean
     description: "Include Exchange Online tests in the test run."
     required: false
-    default: false
+    default: "false"
   include_teams:
-    type: boolean
     description: "Include Teams tests in the test run."
     required: false
-    default: true
+    default: "true"
   include_longrunning_tests:
     description: "Include long running tests."
     required: false
@@ -55,21 +53,18 @@ inputs:
     required: false
     default: "None"
   step_summary:
-    type: boolean
     description: "Define whether a summary is outputted to GitHub Actions."
     required: false
-    default: true
+    default: "true"
   artifact_upload:
-    type: boolean
     description: "Define whether the results are uploaded as Artifacts."
     required: false
-    default: true
+    default: "true"
 
   disable_telemetry:
-    type: boolean
     description: "If set, telemetry information will not be logged."
     required: false
-    default: false
+    default: "false"
 
   mail_recipients:
     description: "A list of email addresses to send the test results to. Please separate multiple email addresses with a comma."

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: "Include Teams tests in the test run."
     required: false
     default: true
+  include_longrunning_tests:
+    description: "Include long running tests."
+    required: false
+    default: "false"
+  include_preview_tests:
+    description: "Include preview tests."
+    required: false
+    default: "false"
   include_tags:
     description: "A list of tags to include in the test run. Please separate multiple tags with a comma (without space)."
     required: false
@@ -154,6 +162,8 @@ runs:
           -IncludePublicTests('${{ inputs.include_public_tests }}' -eq 'true') `
           -IncludeExchange ('${{ inputs.include_exchange }}' -eq 'true') `
           -IncludeTeams ('${{ inputs.include_teams }}' -eq 'true') `
+          -IncludeLongRunning ('${{ inputs.include_longrunning_tests }}' -eq 'true') `
+          -IncludePreview ('${{ inputs.include_preview_tests }}' -eq 'true') `
           -IncludeTags '${{ inputs.include_tags }}' `
           -ExcludeTags '${{ inputs.exclude_tags }}' `
           -DisableTelemetry ('${{ inputs.disable_telemetry}}' -eq 'true') `

--- a/script/Run-MaesterAction.ps1
+++ b/script/Run-MaesterAction.ps1
@@ -251,9 +251,9 @@ PROCESS {
     # A warning to show which parameters are not supported seems better then not executing any tests at all
     $maesterCommand = Get-Command -Name Invoke-Maester
     $missingParameters = $MaesterParameters.Keys | Where-Object { $_ -notin  $maesterCommand.Parameters.Keys }
-    if ($missingParameters) {
-        Write-Host "❌ Maester version: $($maesterCommand.Version) does not support $missingParameters parameters. Please check version compatibility."
-        $MaesterParameters.Remove($missingParameters)
+    foreach ($parameter in $missingParameters) {
+        Write-Host "❌ Maester version: $($maesterCommand.Version) does not support parameter '-$parameter'. Please check version compatibility."
+        $MaesterParameters.Remove($parameter)
     }
 
     try {

--- a/script/Run-MaesterAction.ps1
+++ b/script/Run-MaesterAction.ps1
@@ -36,6 +36,12 @@
     [Parameter(Mandatory = $false, HelpMessage = 'Include Teams tests')]
     [bool]$IncludeTeams = $true,
 
+    [Parameter(Mandatory = $false, HelpMessage = 'Include long running tests')]
+    [bool]$IncludeLongRunning = $true,
+
+    [Parameter(Mandatory = $false, HelpMessage = 'Include preview tests')]
+    [bool]$IncludePreview = $true,
+
     [Parameter(Mandatory = $false, HelpMessage = 'Maester version to install, options: latest, preview, or specific version')]
     [string]$MaesterVersion = '',
 
@@ -189,6 +195,18 @@ PROCESS {
         $ExcludeTestTags = $ExcludeTags -split ','
         $MaesterParameters.Add( 'ExcludeTag', $ExcludeTestTags )
         Write-Host "📃 Excluding tests with tags: $ExcludeTestTags"
+    }
+
+    # Check if long running tests are enabled
+    if ($IncludeLongRunning) {
+         $MaesterParameters.Add('IncludeLongRunning', $true)
+         Write-Host "📃 Including long running tests."
+    }
+
+    # Check if preview tests are enabled
+    if ($IncludePreview) {
+         $MaesterParameters.Add('IncludePreview', $true)
+         Write-Host "📃 Including preview tests."
     }
 
     # Check if mail recipients and mail userid are provided

--- a/script/Run-MaesterAction.ps1
+++ b/script/Run-MaesterAction.ps1
@@ -37,10 +37,10 @@
     [bool]$IncludeTeams = $true,
 
     [Parameter(Mandatory = $false, HelpMessage = 'Include long running tests')]
-    [bool]$IncludeLongRunning = $true,
+    [bool]$IncludeLongRunning = $false,
 
     [Parameter(Mandatory = $false, HelpMessage = 'Include preview tests')]
-    [bool]$IncludePreview = $true,
+    [bool]$IncludePreview = $false,
 
     [Parameter(Mandatory = $false, HelpMessage = 'Maester version to install, options: latest, preview, or specific version')]
     [string]$MaesterVersion = '',


### PR DESCRIPTION
### Description

- Adds inputs for new `-IncludeLongRunning` and `-IncludePreview` parameters in Maester v2.
  - Backwards compatibility is handled by the missing parameters-check as these are new parameters.
- Fixed missing parameter check to handle multiple missing parameters.
- Resolved schema validation errors in `action.yaml` caused by a unsupported `type` property.

Related maester365/maester#1170

/cc @SamErde 

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://github.com/maester365/maester-action/tree/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main branch!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *maester-action/main*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
- [x] If changing anything in the action, make sure it still works and is backward compatible.

### Review

We will try to review your pull request as soon as possible.